### PR TITLE
[fix] Words in the functions names are not separated by underscores

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,7 @@ AMOUNT_RANDOM_STRINGS = 3
 string_generator = list_of_random_strings(AMOUNT_RANDOM_STRINGS)
 
 
-def pytest_addoption(parser):
+def pytest_add_option(parser):
     parser.addoption("--browser", action="store", default="chrome",
                      help="Choose browser: chrome or firefox")
     parser.addoption("--browser_ver", action="store", default="")

--- a/conftest.py
+++ b/conftest.py
@@ -101,7 +101,6 @@ def driver(request, config):
     driver.quit()
 
 
-
 @pytest.fixture(scope='function', params=string_generator)
 def generated_mix_string(request):
     yield request.param


### PR DESCRIPTION
Words in the functions names are not separated by underscores #1 fix