### PR TITLE
Revert "[fix] Words in the functions names are not separated by underscores"

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,7 @@ AMOUNT_RANDOM_STRINGS = 3
 string_generator = list_of_random_strings(AMOUNT_RANDOM_STRINGS)
 
 
-def pytest_add_option(parser):
+def pytest_addoption(parser):
     parser.addoption("--browser", action="store", default="chrome",
                      help="Choose browser: chrome or firefox")
     parser.addoption("--browser_ver", action="store", default="")
@@ -98,6 +98,7 @@ def driver(request, config):
     driver.implicitly_wait(3)
     yield driver
     driver.quit()
+
 
 
 @pytest.fixture(scope='function', params=string_generator)


### PR DESCRIPTION
Reverts Zergoks/InternalEducation#6

pytest cant recognize pytest_add_option function. So it must be pytest_addoption